### PR TITLE
Hide embed.go from embedded file systems

### DIFF
--- a/internal/genny/build/_fixtures/coke/locales/embed.go
+++ b/internal/genny/build/_fixtures/coke/locales/embed.go
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/build/_fixtures/coke/public/embed.go
+++ b/internal/genny/build/_fixtures/coke/public/embed.go
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/build/_fixtures/coke/templates/embed.go
+++ b/internal/genny/build/_fixtures/coke/templates/embed.go
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/build/templates/a/embed.go.plush
+++ b/internal/genny/build/templates/a/embed.go.plush
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/build/templates/migrations/embed.go.plush
+++ b/internal/genny/build/templates/migrations/embed.go.plush
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/newapp/api/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/api/templates/actions/app.go.tmpl
@@ -1,12 +1,12 @@
 package actions
 
 import (
-	{{ if .opts.App.WithPop }}
+	{{ if .opts.App.WithPop -}}
 	"{{ .opts.App.ModelsPkg }}"
 	{{ end -}}
 
 	"github.com/gobuffalo/buffalo"
-	{{ if .opts.App.WithPop }}
+	{{ if .opts.App.WithPop -}}
 	"github.com/gobuffalo/buffalo-pop/v3/pop/popmw"
 	{{ end -}}
 	"github.com/gobuffalo/envy"
@@ -58,12 +58,12 @@ func App() *buffalo.App {
 		// Set the request content type to JSON
 		app.Use(contenttype.Set("application/json"))
 
-		{{ if .opts.App.WithPop }}
+		{{ if .opts.App.WithPop -}}
 		// Wraps each request in a transaction.
 		//   c.Value("tx").(*pop.Connection)
 		// Remove to disable this.
 		app.Use(popmw.Transaction(models.DB))
-		{{ end }}
+		{{ end -}}
 
 		app.GET("/", HomeHandler)
 	}

--- a/internal/genny/newapp/api/templates/locales/embed.go.tmpl
+++ b/internal/genny/newapp/api/templates/locales/embed.go.tmpl
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/newapp/core/templates/README.md.tmpl
+++ b/internal/genny/newapp/core/templates/README.md.tmpl
@@ -19,7 +19,7 @@ Ok, so you've edited the "database.yml" file and started your database, now Buff
 buffalo pop create -a
 ```
 
-{{end -}}
+{{ end -}}
 
 ## Starting the Application
 

--- a/internal/genny/newapp/core/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/core/templates/actions/app.go.tmpl
@@ -30,7 +30,7 @@ func App() *buffalo.App {
 	if app == nil {
 		app = buffalo.New(buffalo.Options{
 			Env:         ENV,
-      SessionName: "_{{.opts.App.Name.File}}_session",
+			SessionName: "_{{.opts.App.Name.File}}_session",
 		})
 
 		// Automatically redirect to SSL

--- a/internal/genny/newapp/web/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/web/templates/actions/app.go.tmpl
@@ -4,11 +4,15 @@ import (
 	"net/http"
 
 	"{{ .opts.App.PackagePkg }}/locales"
-	{{ if .opts.App.WithPop }}"{{ .opts.App.ModelsPkg }}"{{ end -}}
+	{{ if .opts.App.WithPop -}}
+	"{{ .opts.App.ModelsPkg }}"
+	{{ end -}}
 	"{{ .opts.App.PackagePkg }}/public"
 
 	"github.com/gobuffalo/buffalo"
-	{{ if .opts.App.WithPop }}"github.com/gobuffalo/buffalo-pop/v3/pop/popmw"{{ end -}}
+	{{ if .opts.App.WithPop -}}
+	"github.com/gobuffalo/buffalo-pop/v3/pop/popmw"
+	{{ end -}}
 	"github.com/gobuffalo/envy"
 	csrf "github.com/gobuffalo/mw-csrf"
 	forcessl "github.com/gobuffalo/mw-forcessl"

--- a/internal/genny/newapp/web/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/web/templates/actions/app.go.tmpl
@@ -4,15 +4,11 @@ import (
 	"net/http"
 
 	"{{ .opts.App.PackagePkg }}/locales"
-	{{ if .opts.App.WithPop }}
-	"{{ .opts.App.ModelsPkg }}"
-	{{ end -}}
+	{{ if .opts.App.WithPop }}"{{ .opts.App.ModelsPkg }}"{{ end -}}
 	"{{ .opts.App.PackagePkg }}/public"
 
 	"github.com/gobuffalo/buffalo"
-	{{ if .opts.App.WithPop }}
-	"github.com/gobuffalo/buffalo-pop/v3/pop/popmw"
-	{{ end -}}
+	{{ if .opts.App.WithPop }}"github.com/gobuffalo/buffalo-pop/v3/pop/popmw"{{ end -}}
 	"github.com/gobuffalo/envy"
 	csrf "github.com/gobuffalo/mw-csrf"
 	forcessl "github.com/gobuffalo/mw-forcessl"

--- a/internal/genny/newapp/web/templates/locales/embed.go.tmpl
+++ b/internal/genny/newapp/web/templates/locales/embed.go.tmpl
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/newapp/web/templates/public/embed.go.tmpl
+++ b/internal/genny/newapp/web/templates/public/embed.go.tmpl
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/newapp/web/templates/templates/embed.go.tmpl
+++ b/internal/genny/newapp/web/templates/templates/embed.go.tmpl
@@ -9,5 +9,36 @@ import (
 var files embed.FS
 
 func FS() fs.FS {
-	return files
+	return shadowFS{files}
+}
+
+type shadowFS struct {
+	embed.FS
+}
+
+func (f shadowFS) Open(name string) (fs.File, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.Open(name)
+}
+
+func (f shadowFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := f.FS.ReadDir(name)
+	if name == "." {
+		for i, entry := range entries {
+			if entry.Name() == "embed.go" {
+				entries = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return entries, err
+}
+
+func (f shadowFS) ReadFile(name string) ([]byte, error) {
+	if name == "embed.go" {
+		return nil, fs.ErrNotExist
+	}
+	return f.FS.ReadFile(name)
 }

--- a/internal/genny/resource/templates/standard/actions/resource-name.go.tmpl
+++ b/internal/genny/resource/templates/standard/actions/resource-name.go.tmpl
@@ -1,19 +1,18 @@
 package actions
 
 import (
-  "net/http"
+    "net/http"
 
-  "github.com/gobuffalo/buffalo"
+    "github.com/gobuffalo/buffalo"
 )
 
 type {{.opts.Name.Resource}}Resource struct{
-  buffalo.Resource
+    buffalo.Resource
 }
 
 {{ range $a := .actions }}
 // {{$a.Pascalize}} default implementation.
 func (v {{$.opts.Name.Resource}}Resource) {{$a.Pascalize}}(c buffalo.Context) error {
-  return c.Render(http.StatusOK, r.String("{{$.opts.Model.Proper}}#{{$a.Pascalize}}"))
+    return c.Render(http.StatusOK, r.String("{{$.opts.Model.Proper}}#{{$a.Pascalize}}"))
 }
-
-{{end}}
+{{ end }}

--- a/internal/genny/vcs/templates/ignore.tmpl
+++ b/internal/genny/vcs/templates/ignore.tmpl
@@ -23,4 +23,3 @@ jhw.*
 dist/
 generated/
 .vendor/
-


### PR DESCRIPTION
This ensures that the code for embedding is not embedded itself.