### PR TITLE
fixed behavior of info command in non-buffalo directory

### DIFF
--- a/internal/genny/info/info.go
+++ b/internal/genny/info/info.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gobuffalo/genny/v2"
 )
 
+const noBuffalo = "Warning: It seems like it is not a buffalo app. (.buffalo.dev.yml not found)\n\n"
+
 // New returns a generator that performs buffalo
 // related rx checks
 func New(opts *Options) (*genny.Generator, error) {
@@ -16,14 +18,22 @@ func New(opts *Options) (*genny.Generator, error) {
 		return g, err
 	}
 
+	devFile := filepath.Join(opts.App.Root, ".buffalo.dev.yml")
+	if _, err := os.Stat(devFile); err != nil {
+		g.RunFn(func(r *genny.Runner) error {
+			opts.Out.Header("Buffalo: Application Details")
+			return opts.Out.WriteString(noBuffalo)
+		})
+		return g, nil
+	}
+
 	g.RunFn(appDetails(opts))
 
 	path := filepath.Join(opts.App.Root, "config")
-	if err := os.MkdirAll(path, 0755); err != nil {
-		return g, err
+	if _, err := os.Stat(path); err == nil {
+		configFS := os.DirFS(path)
+		g.RunFn(configs(opts, configFS))
 	}
-	configFS := os.DirFS(path)
-	g.RunFn(configs(opts, configFS))
 
 	aFS := os.DirFS(opts.App.Root)
 	g.RunFn(pkgChecks(opts, aFS))


### PR DESCRIPTION
fixed behavior of `info` command not to create empty directory `config` when it runs under non-buffalo source tree.