### PR TITLE
Fix #80 by renaming template names in template.New

### DIFF
--- a/internal/cmd/fix/npm.go
+++ b/internal/cmd/fix/npm.go
@@ -87,7 +87,7 @@ func PackageJSONCheck(r *Runner) error {
 		return err
 	}
 
-	tmpl, err := template.New("package.json").ParseFS(templates, "package.json.tmpl")
+	tmpl, err := template.New("package.json.tmpl").ParseFS(templates, "package.json.tmpl")
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/fix/webpack.go
+++ b/internal/cmd/fix/webpack.go
@@ -25,7 +25,7 @@ func WebpackCheck(r *Runner) error {
 		return err
 	}
 
-	tmpl, err := template.New("webpack").ParseFS(templates, "webpack.config.js.tmpl")
+	tmpl, err := template.New("webpack.config.js.tmpl").ParseFS(templates, "webpack.config.js.tmpl")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #80 by renaming the template names given to `template.New()` in `fix/npm.go` and `fix/webpack.go`. The `template X is an incomplete or empty template` does not appear anymore, allowing me to fix my app to the latest buffalo version.