### PR TITLE
fixed plugin management related bugs

### DIFF
--- a/internal/cmd/fix/plugins.go
+++ b/internal/cmd/fix/plugins.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
-	"strings"
 
 	"github.com/gobuffalo/cli/internal/genny/plugins/install"
 
@@ -16,6 +14,8 @@ import (
 	"github.com/gobuffalo/genny/v2"
 	"github.com/gobuffalo/meta"
 )
+
+var current_pop = "github.com/gobuffalo/buffalo-pop/v3"
 
 //Plugins fixes the plugin configuration of the project by
 //manipulating the plugins .toml file.
@@ -35,6 +35,10 @@ func (pf Plugins) Reinstall(r *Runner) error {
 		return err
 	}
 
+	// TODO: generalize with meta/v2
+	if r.App.WithPop {
+		plugs.Add(plugdeps.NewPlugin(current_pop))
+	}
 	run := genny.WetRunner(context.Background())
 	gg, err := install.New(&install.Options{
 		App:     r.App,
@@ -61,14 +65,11 @@ func (pf Plugins) RemoveOld(r *Runner) error {
 		return err
 	}
 
-	a := strings.TrimSpace("github.com/gobuffalo/buffalo-pop")
-	bin := path.Base(a)
 	plugs.Remove(plugdeps.Plugin{
-		Binary: bin,
-		GoGet:  a,
+		Binary: "buffalo-pop",
 	})
 
-	fmt.Println("~~~ Removing github.com/gobuffalo/buffalo-pop plugin ~~~")
+	fmt.Println("~~~ Removing previous version of buffalo-pop plugin ~~~")
 
 	run.WithRun(cmdPlugins.NewEncodePluginsRunner(app, plugs))
 

--- a/internal/cmd/plugins/add.go
+++ b/internal/cmd/plugins/add.go
@@ -3,9 +3,6 @@ package plugins
 import (
 	"context"
 	"errors"
-	"os"
-	"path"
-	"strings"
 
 	"github.com/gobuffalo/cli/internal/genny/add"
 	"github.com/gobuffalo/cli/internal/plugins/plugdeps"
@@ -36,18 +33,7 @@ var addCmd = &cobra.Command{
 
 		tags := app.BuildTags("", addOptions.buildTags...)
 		for _, a := range args {
-			a = strings.TrimSpace(a)
-			bin := path.Base(a)
-			plug := plugdeps.Plugin{
-				Binary: bin,
-				GoGet:  a,
-				Tags:   tags,
-			}
-			if _, err := os.Stat(a); err == nil {
-				plug.Local = a
-				plug.GoGet = ""
-			}
-			plugs.Add(plug)
+			plugs.Add(plugdeps.NewPlugin(a, tags))
 		}
 		g, err := add.New(&add.Options{
 			App:     app,

--- a/internal/cmd/plugins/cache.go
+++ b/internal/cmd/plugins/cache.go
@@ -18,5 +18,4 @@ func init() {
 	cacheCmd.AddCommand(cache.CleanCmd)
 	cacheCmd.AddCommand(cache.ListCmd)
 	cacheCmd.AddCommand(cache.BuildCmd)
-	PluginsCmd.AddCommand(cacheCmd)
 }

--- a/internal/cmd/plugins/install.go
+++ b/internal/cmd/plugins/install.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
-	"path"
-	"strings"
 
 	"github.com/gobuffalo/cli/internal/genny/plugins/install"
 	"github.com/gobuffalo/cli/internal/plugins/plugdeps"
@@ -48,17 +45,7 @@ var installCmd = &cobra.Command{
 		}
 
 		for _, a := range args {
-			a = strings.TrimSpace(a)
-			bin := path.Base(a)
-			plug := plugdeps.Plugin{
-				Binary: bin,
-				GoGet:  a,
-			}
-			if _, err := os.Stat(a); err == nil {
-				plug.Local = a
-				plug.GoGet = ""
-			}
-			plugs.Add(plug)
+			plugs.Add(plugdeps.NewPlugin(a))
 		}
 		gg, err := install.New(&install.Options{
 			App:     app,

--- a/internal/cmd/plugins/remove.go
+++ b/internal/cmd/plugins/remove.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/gobuffalo/cli/internal/plugins/plugdeps"
@@ -23,7 +22,7 @@ var removeCmd = &cobra.Command{
 	Short: "removes plugin from config/buffalo-plugins.toml",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return fmt.Errorf("you must specify at least one package")
+			return fmt.Errorf("you must specify at least one plugin")
 		}
 		run := genny.WetRunner(context.Background())
 		if removeOptions.dryRun {
@@ -36,12 +35,10 @@ var removeCmd = &cobra.Command{
 			return err
 		}
 
-		for _, a := range args {
-			a = strings.TrimSpace(a)
-			bin := path.Base(a)
+		for _, bin := range args {
+			bin = strings.TrimSpace(bin)
 			plugs.Remove(plugdeps.Plugin{
 				Binary: bin,
-				GoGet:  a,
 			})
 		}
 

--- a/internal/plugins/plugdeps/plugdeps.go
+++ b/internal/plugins/plugdeps/plugdeps.go
@@ -18,9 +18,6 @@ var ErrMissingConfig = fmt.Errorf("could not find a buffalo-plugins config file 
 // Use plugdeps#On(app) to test if plugdeps are being used.
 func List(app meta.App) (*Plugins, error) {
 	plugs := New()
-	if app.WithPop {
-		plugs.Add(pop)
-	}
 
 	lp, err := listLocal(app)
 	if err != nil {

--- a/internal/plugins/plugdeps/plugdeps_test.go
+++ b/internal/plugins/plugdeps/plugdeps_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var pop = Plugin{
+	Binary: "buffalo-pop",
+	GoGet:  "github.com/gobuffalo/buffalo-pop/v3@latest",
+}
+
 var heroku = Plugin{
 	Binary: "buffalo-heroku",
 	GoGet:  "github.com/gobuffalo/buffalo-heroku@latest",

--- a/internal/plugins/plugdeps/plugin.go
+++ b/internal/plugins/plugdeps/plugin.go
@@ -2,9 +2,15 @@ package plugdeps
 
 import (
 	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
 
 	"github.com/gobuffalo/meta"
 )
+
+// bin, module version, and tag
+var re = regexp.MustCompile(`.*(buffalo-[^/]+)/?(v[0-9]+)?@?(.*)?`)
 
 // Plugin represents a Go plugin for Buffalo applications
 type Plugin struct {
@@ -22,5 +28,28 @@ func (p Plugin) String() string {
 }
 
 func (p Plugin) key() string {
-	return p.Binary + p.GoGet + p.Local
+	// p.Binary should be uniq and it can be used as the key
+	return p.Binary
+}
+
+func NewPlugin(mod string, tags ...meta.BuildTags) Plugin {
+	mod = strings.TrimSpace(mod)
+	match := re.FindStringSubmatch(mod)
+	bin := match[1]
+	tag := match[3]
+	plug := Plugin{
+		Binary: bin,
+		GoGet:  mod,
+	}
+	if len(tags) > 0 {
+		plug.Tags = tags[0]
+	}
+	if _, err := os.Stat(mod); err == nil {
+		plug.Local = mod
+		plug.GoGet = ""
+	}
+	if plug.GoGet != "" && tag == "" {
+		plug.GoGet = mod + "@latest"
+	}
+	return plug
 }

--- a/internal/plugins/plugdeps/pop.go
+++ b/internal/plugins/plugdeps/pop.go
@@ -1,6 +1,0 @@
-package plugdeps
-
-var pop = Plugin{
-	Binary: "buffalo-pop",
-	GoGet:  "github.com/gobuffalo/buffalo-pop/v3@latest",
-}


### PR DESCRIPTION
Fixed several bugs related to plugin management:
- fixed related bug on `buffalo fix` (cannot remove old one, just add new one, but filed to go get)
- automatically add `@latest` if the module path has no tag (to make it easy to work with `go install` style)
  - now it supports `buffalo plugins install github.com/gobuffalo/buffalo-pop/v3`
  - along with `buffalo plugins install github.com/gobuffalo/buffalo-pop/v3@latest`
- reliably remove the old version of `buffalo-pop` and install the new one.
- changed command-line argument for `buffalo plugins remove` from package path to plugin name.
  - previously `buffalo plugins remove github.com/gobuffalo/buffalo-pop/v3@latest` (which is not working properly)
  - now `buffalo plugins remove buffalo-pop`, intuitive and simple.
- deduplicated add/install codes (added `plugdeps.NewPlugin()`)
- changed `key()` method. the binary name should be unique, so just use it.
- fixed `cache` registered twice

Detailed issue description and fixed behavior are in #83.

Fixes #83