### PR TITLE
Configure dependabot correctly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "development"
+    labels:
+      - "gomod"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "development"
+    labels:
+      - "github-actions"


### PR DESCRIPTION
Instead of checking main, dependabot should check the development branch for updates to dependencies.