### PR TITLE
Remove unsupported yarn install option. Default to use Yarn berry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Test
         run: |
           go test -tags "sqlite" -cover  ./...
-      
+
       - name: Integration tests
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 0
         run: |
           go test -v -p 1 -tags "sqlite,integration" -cover  ./...

--- a/internal/cmd/setup/frontend.go
+++ b/internal/cmd/setup/frontend.go
@@ -12,12 +12,12 @@ func yarnCheck(app meta.App) error {
 		return err
 	}
 	if _, err := exec.LookPath("yarnpkg"); err != nil {
-		err := run(exec.Command("npm", "install", "-g", "yarn@berry"))
+		err := run(exec.Command("npm", "install", "-g", "yarn"))
 		if err != nil {
 			return fmt.Errorf("This application require yarn, and we could not find it installed on your system. We tried to install it for you, but ran into the following error:\n%s", err)
 		}
 	}
-	if err := run(exec.Command("yarnpkg", "install", "--silent")); err != nil {
+	if err := run(exec.Command("yarnpkg", "install")); err != nil {
 		return fmt.Errorf("We encountered the following error when trying to install your asset dependencies using yarn:\n%s", err)
 	}
 	return nil

--- a/internal/cmd/setup/frontend.go
+++ b/internal/cmd/setup/frontend.go
@@ -12,12 +12,12 @@ func yarnCheck(app meta.App) error {
 		return err
 	}
 	if _, err := exec.LookPath("yarnpkg"); err != nil {
-		err := run(exec.Command("npm", "install", "-g", "yarn"))
+		err := run(exec.Command("npm", "install", "-g", "yarn@berry"))
 		if err != nil {
 			return fmt.Errorf("This application require yarn, and we could not find it installed on your system. We tried to install it for you, but ran into the following error:\n%s", err)
 		}
 	}
-	if err := run(exec.Command("yarnpkg", "install", "--no-progress")); err != nil {
+	if err := run(exec.Command("yarnpkg", "install", "--silent")); err != nil {
 		return fmt.Errorf("We encountered the following error when trying to install your asset dependencies using yarn:\n%s", err)
 	}
 	return nil

--- a/internal/genny/assets/webpack/templates/dot-yarnrc.yml.tmpl
+++ b/internal/genny/assets/webpack/templates/dot-yarnrc.yml.tmpl
@@ -1,0 +1,4 @@
+enableGlobalCache: true
+logFilters:
+  - code: YN0013
+    level: discard

--- a/internal/genny/assets/webpack/templates/dot-yarnrc.yml.tmpl
+++ b/internal/genny/assets/webpack/templates/dot-yarnrc.yml.tmpl
@@ -1,4 +1,0 @@
-enableGlobalCache: true
-logFilters:
-  - code: YN0013
-    level: discard

--- a/internal/genny/assets/webpack/templates/package.json.tmpl
+++ b/internal/genny/assets/webpack/templates/package.json.tmpl
@@ -25,6 +25,7 @@
     "css-loader": "~3.5.1",
     "expose-loader": "^3.0.0",
     "file-loader": "~6.0.0",
+    "glob": "^7.2.0",
     "gopherjs-loader": "^0.0.1",
     "mini-css-extract-plugin": "^2.0.0",
     "npm-install-webpack-plugin": "4.0.5",
@@ -34,7 +35,7 @@
     "style-loader": "~1.1.3",
     "terser-webpack-plugin": "~2.3.1",
     "url-loader": "~4.1.0",
-    "webpack": "~5.52.0",
+    "webpack": "~5.65.0",
     "webpack-cli": "^4.0.0",
     "webpack-livereload-plugin": "^3.0.0",
     "webpack-manifest-plugin": "^4.0.0"

--- a/internal/genny/assets/webpack/templates/webpack.config.js.tmpl
+++ b/internal/genny/assets/webpack/templates/webpack.config.js.tmpl
@@ -48,7 +48,6 @@ const configurator = {
             ignore: [
               "**/css/**", 
               "**/js/**", 
-              "**/src/**",
             ]
           }
         }],

--- a/internal/genny/assets/webpack/webpack.go
+++ b/internal/genny/assets/webpack/webpack.go
@@ -88,7 +88,7 @@ func New(opts *Options) (*genny.Generator, error) {
 
 func installPkgs(r *genny.Runner, opts *Options) error {
 	command := "yarnpkg"
-	args := []string{"install", "--silent"}
+	args := []string{"install"}
 
 	if !opts.App.WithYarn {
 		command = "npm"

--- a/internal/genny/assets/webpack/webpack.go
+++ b/internal/genny/assets/webpack/webpack.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gobuffalo/genny/v2/gogen"
 )
 
+const YARN = "yarn"
+
 //go:embed templates/* templates/assets/css/_buffalo.scss.tmpl
 var templates embed.FS
 
@@ -41,7 +43,7 @@ func New(opts *Options) (*genny.Generator, error) {
 
 	g.RunFn(func(r *genny.Runner) error {
 		if opts.App.WithYarn {
-			if _, err := r.LookPath("yarnpkg"); err == nil {
+			if _, err := r.LookPath(YARN); err == nil {
 				return nil
 			}
 			// If yarn is not installed, it still can be installed with npm.
@@ -87,7 +89,7 @@ func New(opts *Options) (*genny.Generator, error) {
 }
 
 func installPkgs(r *genny.Runner, opts *Options) error {
-	command := "yarnpkg"
+	command := YARN
 	args := []string{"install"}
 
 	if !opts.App.WithYarn {
@@ -97,11 +99,12 @@ func installPkgs(r *genny.Runner, opts *Options) error {
 		if err := installYarn(r); err != nil {
 			return err
 		}
-		if err := r.Exec(exec.Command(command, []string{"set", "version", "berry"}...)); err != nil {
+		if err := setupYarnBerry(r); err != nil {
 			return err
 		}
 	}
 
+	r.Exec(exec.Command(command, "--version"))
 	c := exec.Command(command, args...)
 	c.Stdout = yarnWriter{
 		fn: r.Logger.Debug,
@@ -123,9 +126,27 @@ func (y yarnWriter) Write(p []byte) (int, error) {
 
 func installYarn(r *genny.Runner) error {
 	// if there's no yarn, install it!
-	if _, err := r.LookPath("yarnpkg"); err == nil {
+	if _, err := r.LookPath(YARN); err == nil {
 		return nil
 	}
 	yargs := []string{"install", "-g", "yarn"}
 	return r.Exec(exec.Command("npm", yargs...))
+}
+
+func setupYarnBerry(r *genny.Runner) error {
+	if err := r.Exec(exec.Command(YARN, "--version")); err != nil {
+		return err
+	}
+	if err := r.Exec(exec.Command(YARN, "set", "version", "berry")); err != nil {
+		return err
+	}
+	// the yarnrc config format is different between classic and berry so
+	// it should be configured after berry installation (set version)
+	if err := r.Exec(exec.Command(YARN, "config", "set", "enableGlobalCache", "true")); err != nil {
+		return err
+	}
+	if err := r.Exec(exec.Command(YARN, "config", "set", "logFilters", "--json", `[{"code":"YN0013","level":"discard"}]`)); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/genny/assets/webpack/webpack.go
+++ b/internal/genny/assets/webpack/webpack.go
@@ -88,15 +88,19 @@ func New(opts *Options) (*genny.Generator, error) {
 
 func installPkgs(r *genny.Runner, opts *Options) error {
 	command := "yarnpkg"
+	args := []string{"install", "--silent"}
 
 	if !opts.App.WithYarn {
 		command = "npm"
+		args = []string{"install", "--no-progress", "--save"}
 	} else {
 		if err := installYarn(r); err != nil {
 			return err
 		}
+		if err := r.Exec(exec.Command(command, []string{"set", "version", "berry"}...)); err != nil {
+			return err
+		}
 	}
-	args := []string{"install", "--no-progress", "--save"}
 
 	c := exec.Command(command, args...)
 	c.Stdout = yarnWriter{

--- a/internal/genny/assets/webpack/webpack_test.go
+++ b/internal/genny/assets/webpack/webpack_test.go
@@ -30,13 +30,14 @@ func Test_Webpack_New(t *testing.T) {
 	r.NoError(run.Run())
 
 	res := run.Results()
-	r.Len(res.Commands, 1)
+	r.Len(res.Commands, 2)
 	c := res.Commands[0]
+	r.Equal("npm --version", strings.Join(c.Args, " "))
+	c = res.Commands[1]
 	r.Equal("npm install --no-progress --save", strings.Join(c.Args, " "))
 
 	files := []string{
 		".babelrc",
-		".yarnrc.yml",
 		"assets/css/_buffalo.scss",
 		"assets/css/application.scss",
 		"assets/images/favicon.ico",
@@ -71,14 +72,17 @@ func Test_Webpack_New_WithYarn(t *testing.T) {
 	r.NoError(run.Run())
 
 	res := run.Results()
-	r.Len(res.Commands, 2)
-	r.Len(res.Files, 12)
+	r.Len(res.Commands, 6)
+	r.Len(res.Files, 11) // see file list in Test_Webpack_New
 
-	berryCommand := res.Commands[0]
-	r.Equal("yarnpkg set version berry", strings.Join(berryCommand.Args, " "))
+	versionCommand := res.Commands[0]
+	r.Equal("yarn --version", strings.Join(versionCommand.Args, " "))
 
-	installCommand := res.Commands[1]
-	r.Equal("yarnpkg install", strings.Join(installCommand.Args, " "))
+	berryCommand := res.Commands[1]
+	r.Equal("yarn set version berry", strings.Join(berryCommand.Args, " "))
+
+	installCommand := res.Commands[5]
+	r.Equal("yarn install", strings.Join(installCommand.Args, " "))
 }
 
 const layout = `<!DOCTYPE html>

--- a/internal/genny/assets/webpack/webpack_test.go
+++ b/internal/genny/assets/webpack/webpack_test.go
@@ -36,6 +36,7 @@ func Test_Webpack_New(t *testing.T) {
 
 	files := []string{
 		".babelrc",
+		".yarnrc.yml",
 		"assets/css/_buffalo.scss",
 		"assets/css/application.scss",
 		"assets/images/favicon.ico",
@@ -70,11 +71,14 @@ func Test_Webpack_New_WithYarn(t *testing.T) {
 	r.NoError(run.Run())
 
 	res := run.Results()
-	r.Len(res.Commands, 1)
-	r.Len(res.Files, 11)
+	r.Len(res.Commands, 2)
+	r.Len(res.Files, 12)
 
-	c := res.Commands[0]
-	r.Equal("yarnpkg install --no-progress --save", strings.Join(c.Args, " "))
+	berryCommand := res.Commands[0]
+	r.Equal("yarnpkg set version berry", strings.Join(berryCommand.Args, " "))
+
+	installCommand := res.Commands[1]
+	r.Equal("yarnpkg install", strings.Join(installCommand.Args, " "))
 }
 
 const layout = `<!DOCTYPE html>

--- a/internal/genny/docker/templates/dot-dockerignore.tmpl
+++ b/internal/genny/docker/templates/dot-dockerignore.tmpl
@@ -1,4 +1,10 @@
 node_modules/
 .pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 *.log
 bin/

--- a/internal/genny/docker/templates/dot-dockerignore.tmpl
+++ b/internal/genny/docker/templates/dot-dockerignore.tmpl
@@ -1,3 +1,4 @@
 node_modules/
+.pnp.*
 *.log
 bin/

--- a/internal/genny/vcs/templates/ignore.tmpl
+++ b/internal/genny/vcs/templates/ignore.tmpl
@@ -23,3 +23,10 @@ jhw.*
 dist/
 generated/
 .vendor/
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
Resolves this Issue: https://github.com/gobuffalo/cli/issues/95

Yarn 2+ (berry) is not supported on `buffalo new`. These changes allow for Yarn 1.x (classic) and 2.x+ (berry) to work, and also defaults to using the latest Yarn berry on setup.