### PR TITLE
Replaces jQuery-UJS with non-jQuery alternative, drops jQuery altogether

### DIFF
--- a/internal/genny/assets/webpack/templates/assets/js/application.js.tmpl
+++ b/internal/genny/assets/webpack/templates/assets/js/application.js.tmpl
@@ -1,8 +1,7 @@
-require("expose-loader?exposes=$,jQuery!jquery");
 require("bootstrap/dist/js/bootstrap.bundle.js");
 require("@fortawesome/fontawesome-free/js/all.js");
-require("jquery-ujs/src/rails.js");
+require("@rails/ujs").start();
 
-$(() => {
+document.addEventListener("DOMContentLoaded", (_event) => {
 
 });

--- a/internal/genny/assets/webpack/templates/package.json.tmpl
+++ b/internal/genny/assets/webpack/templates/package.json.tmpl
@@ -11,9 +11,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
     "@popperjs/core": "^2.0.0",
-    "bootstrap": "^5.0.0",
-    "jquery": "^3.6.0",
-    "jquery-ujs": "^1.2.2"
+    "@rails/ujs": "^7.0.0",
+    "bootstrap": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/internal/genny/assets/webpack/templates/webpack.config.js.tmpl
+++ b/internal/genny/assets/webpack/templates/webpack.config.js.tmpl
@@ -36,10 +36,6 @@ const configurator = {
 
   plugins() {
     var plugins = [
-      new Webpack.ProvidePlugin({
-        $: "jquery",
-        jQuery: "jquery"
-      }),
       new MiniCssExtractPlugin({filename: "[name].[contenthash].css"}),
       new CopyWebpackPlugin({
         patterns: [{


### PR DESCRIPTION
Bootstrap 5 doesn't require jQuery anymore and UJS was the only holdout. Many frontend devs agree that the browser APIs have sufficiently stabilized and centered on a user-friendly standard interface such that jQuery is no longer needed. See https://youmightnotneedjquery.com/ for more.

Given Ruby on Rails has dropped jQuery as a dependency since 5.x (current is 7.x), it seems it's about time Buffalo does the same.

rails-ujs is a nearly drop-in replacement for jquery-ujs. For scaffolding purposes, it is a minor change in a couple files (this commit alone) and no changes to how forms need to be rendered. Also of note is that rails-ujs can still work with jQuery if desired.