### PR TITLE
visibility and limiting on using `testhelpers.getBuffaloUrl`

### DIFF
--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -35,6 +35,8 @@ func getBuffaloUrl(version string) (string, error) {
 		}
 		if resp.StatusCode == http.StatusOK {
 			return fmt.Sprintf("%s@%s", v.installUrl, version), nil
+		} else if resp.StatusCode != http.StatusNotFound {
+			return "", fmt.Errorf("unexpected response for %v: %v", url, resp.StatusCode)
 		}
 	}
 

--- a/internal/testhelpers/testhelpers_test.go
+++ b/internal/testhelpers/testhelpers_test.go
@@ -28,6 +28,12 @@ func Test_EnsureBuffaloCMD(t *testing.T) {
 }
 
 func Test_InstallOldBuffaloCMD(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// this test calls api.github.com too much.
+		// no reason for linux, but just reduce the calls as 1/3
+		t.Skip("skipping Test_InstallOldBuffaloCMD (non-linux env)")
+	}
+
 	tt := []struct {
 		name    string
 		version string


### PR DESCRIPTION
While testing #96, the test case for `InstallOldBuffaloCMD()` keeps failing but it's not easy to find the reason.