### PR TITLE
Fix test database creation error

### DIFF
--- a/internal/cmd/test/test.go
+++ b/internal/cmd/test/test.go
@@ -27,7 +27,8 @@ func runE(c *cobra.Command, args []string) error {
 
 		// drop the test db:
 		if err := test.Dialect.DropDB(); err != nil {
-			return err
+			// not an error, since the database will be created in the next step anyway
+			logrus.Info("no test database to drop")
 		}
 
 		// create the test db:


### PR DESCRIPTION
This fixes issue #105.

If the "test" database cannot be dropped, just log it instead of returning with an error