### PR TITLE
fixed glob error related to copy-webpack-plugin

### DIFF
--- a/internal/cmd/build/build_test.go
+++ b/internal/cmd/build/build_test.go
@@ -41,10 +41,13 @@ func TestBuild(t *testing.T) {
 			appname:      "sqlite",
 		},
 		{
+			// this test covers too things at once (to save testing time)
+			// 1. originally this test case is for `--skip-pop`
+			// 2. by using "src" as appname, it covers webpack-copy glob issue (pull/119)
 			name:         "skipop",
-			newargs:      []string{"new", "skipop", "-f", "--skip-pop", "--vcs", "none"},
+			newargs:      []string{"new", "src", "-f", "--skip-pop", "--vcs", "none"},
 			resourceargs: []string{"g", "action", "phone", "new"},
-			appname:      "skipop",
+			appname:      "src",
 		},
 	}
 

--- a/internal/genny/assets/webpack/templates/webpack.config.js.tmpl
+++ b/internal/genny/assets/webpack/templates/webpack.config.js.tmpl
@@ -46,8 +46,9 @@ const configurator = {
           from: "./assets",
           globOptions: {
             ignore: [
-              "**/css/**", 
-              "**/js/**", 
+              "**/assets/css/**",
+              "**/assets/js/**",
+              "**/assets/src/**",
             ]
           }
         }],


### PR DESCRIPTION
It solves the issue related to the `copy-webpack-plugin` (currently https://github.com/gobuffalo/buffalo/issues/2203, should be moved here). Testcase also applied. (with a small fix on the existing one)

**short description**
If the application source tree is under a path that contains one of `/src/`, `/css/`, and `/js/` such as `/home/me/src/myapp`, webpack build will fail with error like

```
ERROR in unable to locate '/src/coke/assets/**/*' glob
```

**Related to**
[1] https://gophers.slack.com/archives/C3MSAFD40/p1638800743045400
[2] https://github.com/webpack-contrib/copy-webpack-plugin/issues/519#issuecomment-672898425
[3] https://github.com/mrmlnc/fast-glob/issues/285#issuecomment-674410782