### PR TITLE
fixed "too many open files" error of fixer with except-fs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gobuffalo/envy v1.10.1
 	github.com/gobuffalo/events v1.4.2
 	github.com/gobuffalo/flect v0.2.4
-	github.com/gobuffalo/genny/v2 v2.0.8
+	github.com/gobuffalo/genny/v2 v2.0.9
 	github.com/gobuffalo/logger v1.0.6
 	github.com/gobuffalo/meta v0.3.1
 	github.com/gobuffalo/plush/v4 v4.1.9

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,9 @@ github.com/gobuffalo/fizz v1.14.0/go.mod h1:0aF1kAZYCfKqbLM/lmZ3jXFyqqWE/kY/nIOK
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/flect v0.2.4 h1:BSYA8+T60cdyq+vynaSUjqSVI9mDEg9ZfQUXKmfjo4I=
 github.com/gobuffalo/flect v0.2.4/go.mod h1:1ZyCLIbg0YD7sDkzvFdPoOydPtD8y9JQnrOROolUcM8=
-github.com/gobuffalo/genny/v2 v2.0.8 h1:ZMQGusokXiFFOOMOKujcR3SqwxD3ZSlLwc81PMV0ww0=
 github.com/gobuffalo/genny/v2 v2.0.8/go.mod h1:R45scCyQfff2HysNJHNanjrpvPw4Qu+rM1MOMDBB5oU=
+github.com/gobuffalo/genny/v2 v2.0.9 h1:owT4OjHEDKnfL3V+A0fl6ipsNiSW0ILf0bFKIIMB/7A=
+github.com/gobuffalo/genny/v2 v2.0.9/go.mod h1:R45scCyQfff2HysNJHNanjrpvPw4Qu+rM1MOMDBB5oU=
 github.com/gobuffalo/github_flavored_markdown v1.1.0/go.mod h1:TSpTKWcRTI0+v7W3x8dkSKMLJSUpuVitlptCkpeY8ic=
 github.com/gobuffalo/github_flavored_markdown v1.1.1 h1:kUf8ginyBOTRXcKSTPsPAqlA25vQ80+xAspLIYaxmTU=
 github.com/gobuffalo/github_flavored_markdown v1.1.1/go.mod h1:yU32Pen+eorS58oxh/bNZx76zUOCJwmvyV5FBrvzOKQ=

--- a/internal/genny/fix/fix.go
+++ b/internal/genny/fix/fix.go
@@ -65,7 +65,9 @@ func New(opts *Options) (*genny.Generator, error) {
 		return nil
 	})
 
-	if err := g.FS(os.DirFS(opts.App.Root)); err != nil {
+	// ExceptFS will not scan any files that the path starts with given strings
+	// excluded files include such as `.git/`, `.github/`, `.gitignore`, `.yarn/`, `.yarnrc`, etc.
+	if err := g.ExceptFS(os.DirFS(opts.App.Root), []string{"node_modules", ".git", ".yarn"}, nil); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
By introducing and using `Generator.ExceptFS()` for the fixer, fixing #116 and improving scanning speed for the `buffalo fix`. The selective filesystem was implemented as https://github.com/gobuffalo/genny/pull/44.

fixes #116 