### PR TITLE
Task updating UJS

### DIFF
--- a/internal/genny/assets/webpack/templates/assets/js/application.js.tmpl
+++ b/internal/genny/assets/webpack/templates/assets/js/application.js.tmpl
@@ -1,7 +1,11 @@
 require("expose-loader?exposes=$,jQuery!jquery");
 require("bootstrap/dist/js/bootstrap.bundle.js");
 require("@fortawesome/fontawesome-free/js/all.js");
-require("jquery-ujs/src/rails.js");
+
+// Initializing UJS, this takes care of things 
+// like `data-confirm` and `data-method`.
+let ujs = require("@rails/ujs")
+ujs.start();
 
 $(() => {
 

--- a/internal/genny/assets/webpack/templates/package.json.tmpl
+++ b/internal/genny/assets/webpack/templates/package.json.tmpl
@@ -11,9 +11,10 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
     "@popperjs/core": "^2.0.0",
+    "@rails/ujs": "^7.0.0",
+    
     "bootstrap": "^5.0.0",
-    "jquery": "^3.6.0",
-    "jquery-ujs": "^1.2.2"
+    "jquery": "^3.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
This PR is based on #97 but only replaces the UJS library to use the non-jquery version of it from the Rails team. This may set us closer to non-jquery version of our standard app without breaking existing functionallity.