### PR TITLE
internal/cmd/build: Enable passing of additional build flags to 'go build'

### DIFF
--- a/internal/cmd/build/cmd.go
+++ b/internal/cmd/build/cmd.go
@@ -23,6 +23,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().BoolVar(&buildOptions.CleanAssets, "clean-assets", false, "will delete public/assets before calling webpack")
 	cmd.Flags().StringVarP(&buildOptions.Environment, "environment", "", "development", "set the environment for the binary")
 	cmd.Flags().StringVar(&buildOptions.Mod, "mod", "", "-mod flag for go build")
+	cmd.Flags().StringSliceVar(&buildOptions.BuildFlags, "build-flags", nil, "Additional comma-separated build flags to feed to go build")
 
 	return cmd
 }


### PR DESCRIPTION
Addresses #108

Simple one-liner that has been working for me.