### PR TITLE
respect context in dev mode (auto refreshing)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/markbates/grift v1.5.0
 	github.com/markbates/oncer v1.0.0
-	github.com/markbates/refresh v1.12.0
 	github.com/markbates/safe v1.0.1
 	github.com/markbates/sigtx v1.0.0
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef

--- a/go.sum
+++ b/go.sum
@@ -449,7 +449,6 @@ github.com/markbates/grift v1.5.0 h1:CZyK0k+8BdhQMgbwzuKMysC12y4tf9H004jAs/FutX4
 github.com/markbates/grift v1.5.0/go.mod h1:1ssFm5gSGmzTkhi3Wfh/nqlU74J73TlAjoDMttQbpfY=
 github.com/markbates/oncer v1.0.0 h1:E83IaVAHygyndzPimgUYJjbshhDTALZyXxvk9FOlQRY=
 github.com/markbates/oncer v1.0.0/go.mod h1:Z59JA581E9GP6w96jai+TGqafHPW+cPfRxz2aSZ0mcI=
-github.com/markbates/refresh v1.12.0 h1:vTgVPX4p77v26auBJhlgaTQ/adWAYSIcVYJvM63Nbpo=
 github.com/markbates/refresh v1.12.0/go.mod h1:Vpwi1+q+2U1VxE7C0Ilj6r2/+TigRzQcLez6XM3bPLc=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=

--- a/internal/cmd/dev/dev.go
+++ b/internal/cmd/dev/dev.go
@@ -13,7 +13,7 @@ import (
 	rg "github.com/gobuffalo/cli/internal/genny/refresh"
 	"github.com/gobuffalo/genny/v2"
 	"github.com/gobuffalo/meta"
-	"github.com/markbates/refresh/refresh"
+	"github.com/gobuffalo/refresh/refresh"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"


### PR DESCRIPTION
When running the `buffalo dev` command where there is no `yarnpkg` command in the path, the command shows an error message (context canceled) but does not exit from the rebuild loop. Since the only method to escape from this situation is hitting `^C`, users cannot get any useful message about the reason for the execution failure.

```console
$ buffalo dev
buffalo: 2022/05/02 23:00:02 === Rebuild on: :start: ===
buffalo: 2022/05/02 23:00:02 === Error! ===
buffalo: 2022/05/02 23:00:02 === context canceled
 ===
^C
$ 
```

The root cause of this issue is on the [markbates/refresh](https://github.com/markbates/refresh) package since the refresh runner does not escape from the refresh loop when the manager's context is already canceled.

I filed a PR for the package (https://github.com/markbates/refresh/pull/49) and it will fix the root cause. However, having this fix in this buffalo cli itself could be the best/solid solution. (Also it could be a workaround until the patch is applied to the refresh.)

By this PR, we cli will escape from the loop and will print the reason of failure:

```console
$ buffalo dev
ERRO[0000] There was a problem starting the dev server, Please review the troubleshooting docs: Unknown 
buffalo: 2022/05/02 23:00:20 === Rebuild on: :start: ===
buffalo: 2022/05/02 23:00:20 === Error! ===
buffalo: 2022/05/02 23:00:20 === context canceled
 ===
Usage:
  buffalo dev [flags]

Flags:
  -d, --debug   use delve to debug the app
  -h, --help    help for dev

ERRO[0000] Error: could not find yarnpkg tool           
$ 
```