### PR TITLE
Reduce dependencies on external libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/gobuffalo/refresh v1.13.1
 	github.com/google/go-cmp v0.5.8
 	github.com/markbates/grift v1.5.0
-	github.com/markbates/safe v1.0.1
 	github.com/markbates/sigtx v1.0.0
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gobuffalo/events v1.4.2
 	github.com/gobuffalo/flect v0.2.5
 	github.com/gobuffalo/genny/v2 v2.0.9
-	github.com/gobuffalo/here v0.6.6 // indirect
 	github.com/gobuffalo/logger v1.0.6
 	github.com/gobuffalo/meta v0.3.1
 	github.com/gobuffalo/plush/v4 v4.1.11
@@ -20,7 +19,6 @@ require (
 	github.com/gobuffalo/refresh v1.13.1
 	github.com/google/go-cmp v0.5.8
 	github.com/markbates/grift v1.5.0
-	github.com/markbates/oncer v1.0.0
 	github.com/markbates/safe v1.0.1
 	github.com/markbates/sigtx v1.0.0
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/gobuffalo/helpers v0.6.4/go.mod h1:m2aOKsTl3KB0RUwwpxf3tykaaitujQ3iri
 github.com/gobuffalo/here v0.4.0/go.mod h1:bTNk/uKZgycuB358iR0D32dI9kHBClBGpXjW2HVHkNo=
 github.com/gobuffalo/here v0.6.5 h1:OjrFcVbQBXff4EN+/m2xa+i1Wy6lW+3fn9Jf+b5WDXY=
 github.com/gobuffalo/here v0.6.5/go.mod h1:y6q8eG7YstM/DfOKKAyHV1plrNsuYS5dcIerm8Habas=
-github.com/gobuffalo/here v0.6.6 h1:/o+jfSwe36pKQ577grsXGoMYql/zheiGwg1XFo3CBJU=
-github.com/gobuffalo/here v0.6.6/go.mod h1:C4JZL5PsXWKzP/CAchaIzuUWlaae6CaAiMYQ0ieY62M=
 github.com/gobuffalo/httptest v1.5.1/go.mod h1:uEeEFF2BRyTMNAATqFQAKYvpHrWWPNoJbIB3YPuANNM=
 github.com/gobuffalo/logger v1.0.6 h1:nnZNpxYo0zx+Aj9RfMPBm+x9zAU2OayFh/xrAWi34HU=
 github.com/gobuffalo/logger v1.0.6/go.mod h1:J31TBEHR1QLV2683OXTAItYIg8pv2JMHnF/quuAbMjs=

--- a/internal/cmd/plugins.go
+++ b/internal/cmd/plugins.go
@@ -1,16 +1,18 @@
 package cmd
 
 import (
+	"sync"
+
 	"github.com/gobuffalo/cli/internal/plugins"
-	"github.com/markbates/oncer"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var _plugs plugins.List
+var initPlugsOnce sync.Once
 
 func plugs() plugins.List {
-	oncer.Do("buffalo/cmd/plugins", func() {
+	initPlugsOnce.Do(func() {
 		var err error
 		_plugs, err = plugins.Available()
 		if err == nil {

--- a/internal/plugins/events.go
+++ b/internal/plugins/events.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/events"
-	"github.com/markbates/oncer"
 	"github.com/markbates/safe"
 )
 
@@ -19,10 +19,12 @@ const (
 	EvtSetupFinished = "buffalo-plugins:setup:finished"
 )
 
+var loadPluginsOnce sync.Once
+
 // Load will add listeners for any plugins that support "events"
 func Load() error {
 	var errResult error
-	oncer.Do("events.LoadPlugins", func() {
+	loadPluginsOnce.Do(func() {
 		// don't send plugins events during testing
 		if envy.Get("GO_ENV", "development") == "test" {
 			return


### PR DESCRIPTION
This removes dependencies to the following externals:

* `github.com/markbates/oncer` - functionality is trivial, just used `sync.Once` instead
* `github.com/markbates/safe` - Inlined in one place, removed in another (code doesn't panic so no need to "safe" it)