### PR TITLE
Task dockerfile 1.18

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 EXPOSE 3000
 

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.18-alpine
 
 EXPOSE 3000
 


### PR DESCRIPTION
This PR changes our builder Docker images to be based in Go 1.18.

cc @sio4 @fasmat 