### PR TITLE
fixed regex bug on plugin installation match (related to #84)

### DIFF
--- a/internal/plugins/plugdeps/plugin.go
+++ b/internal/plugins/plugdeps/plugin.go
@@ -10,7 +10,7 @@ import (
 )
 
 // bin, module version, and tag
-var re = regexp.MustCompile(`.*(buffalo-[^/]+)/?(v[0-9]+)?@?(.*)?`)
+var re = regexp.MustCompile(`.*(buffalo-[^/@]+)/?(v[0-9]+)?@?(.*)?`)
 
 // Plugin represents a Go plugin for Buffalo applications
 type Plugin struct {

--- a/internal/plugins/plugdeps/plugin_test.go
+++ b/internal/plugins/plugdeps/plugin_test.go
@@ -1,1 +1,59 @@
 package plugdeps
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPlugin_NoVersionNoTag(t *testing.T) {
+	r := require.New(t)
+
+	p := NewPlugin("example.com/user/buffalo-awesome")
+	r.Equal("buffalo-awesome", p.key())
+	r.Equal("buffalo-awesome", p.Binary)
+	r.Equal("example.com/user/buffalo-awesome@latest", p.GoGet)
+
+	r.Equal(meta.BuildTags(nil), p.Tags)
+	r.Equal(`{"binary":"buffalo-awesome","go_get":"example.com/user/buffalo-awesome@latest"}`, p.String())
+}
+
+func TestNewPlugin_BuildTags(t *testing.T) {
+	r := require.New(t)
+
+	p := NewPlugin("example.com/user/buffalo-awesome", meta.BuildTags{"sqlite", "awesome"})
+	r.Equal("buffalo-awesome", p.key())
+	r.Equal("buffalo-awesome", p.Binary)
+	r.Equal("example.com/user/buffalo-awesome@latest", p.GoGet)
+
+	r.Equal(meta.BuildTags{"sqlite", "awesome"}, p.Tags)
+	r.Equal(`{"binary":"buffalo-awesome","go_get":"example.com/user/buffalo-awesome@latest","tags":["sqlite","awesome"]}`, p.String())
+}
+
+func TestNewPlugin_NoVersionTag(t *testing.T) {
+	r := require.New(t)
+
+	p := NewPlugin("example.com/user/buffalo-awesome@v3.1")
+	r.Equal("buffalo-awesome", p.key())
+	r.Equal("buffalo-awesome", p.Binary)
+	r.Equal("example.com/user/buffalo-awesome@v3.1", p.GoGet)
+}
+
+func TestNewPlugin_VersionNoTag(t *testing.T) {
+	r := require.New(t)
+
+	p := NewPlugin("example.com/user/buffalo-awesome/v3")
+	r.Equal("buffalo-awesome", p.key())
+	r.Equal("buffalo-awesome", p.Binary)
+	r.Equal("example.com/user/buffalo-awesome/v3@latest", p.GoGet)
+}
+
+func TestNewPlugin_VersionTag(t *testing.T) {
+	r := require.New(t)
+
+	p := NewPlugin("example.com/user/buffalo-awesome/v3@v3.1")
+	r.Equal("buffalo-awesome", p.key())
+	r.Equal("buffalo-awesome", p.Binary)
+	r.Equal("example.com/user/buffalo-awesome/v3@v3.1", p.GoGet)
+}

--- a/internal/plugins/plugdeps/plugins.go
+++ b/internal/plugins/plugdeps/plugins.go
@@ -32,7 +32,7 @@ func (plugs *Plugins) Decode(r io.Reader) error {
 	tp := &tomlPlugins{
 		Plugins: []Plugin{},
 	}
-	if _, err := toml.DecodeReader(r, tp); err != nil {
+	if _, err := toml.NewDecoder(r).Decode(tp); err != nil {
 		return err
 	}
 	for _, p := range tp.Plugins {


### PR DESCRIPTION
I made a mistake when I wrote a regex for `NewPlugin()`. It prevented adding a version tag when running the `buffalo plugin install` command. This PR fixed that issue and added test cases.

#### Issue
* `buffalo plugin install github.com/gobuffalo/buffalo-awesome/v2` works
* `buffalo plugin install github.com/gobuffalo/buffalo-awesome/v2@latest` works
* `buffalo plugin install github.com/gobuffalo/buffalo-awesome` works
* `buffalo plugin install github.com/gobuffalo/buffalo-awesome@latest` doesn't work
   * was interpreted as `buffalo-awesome@latest` is the command name

#### Fix
* fixed regex to care `@` too.

Additionally, fixed one deprecation warning on `Plugins.Decode()`.

related previous pr: #84