### PR TITLE
fixed a bug where dryrun destroys existing app directly

### DIFF
--- a/internal/cmd/new/new.go
+++ b/internal/cmd/new/new.go
@@ -46,7 +46,7 @@ func RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	run.Root = app.Root
-	if nopts.Force {
+	if nopts.Force && !nopts.DryRun {
 		os.RemoveAll(app.Root)
 	}
 

--- a/internal/cmd/new/new_test.go
+++ b/internal/cmd/new/new_test.go
@@ -77,6 +77,21 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewDryRun(t *testing.T) {
+	r := require.New(t)
+	r.NoError(testhelpers.EnsureBuffaloCMD(t))
+
+	testhelpers.RunWithinTempFolder(t, func(t *testing.T) {
+		r := require.New(t)
+		_, err := testhelpers.RunBuffaloCMD(t, []string{"new", "app", "-f", "--api"})
+		r.NoError(err)
+		r.DirExists("app")
+		_, err = testhelpers.RunBuffaloCMD(t, []string{"new", "app", "-d", "-f", "--api"})
+		r.NoError(err)
+		r.DirExists("app", "dryrun should not destroy anything but...")
+	})
+}
+
 func TestNewAppAPIContent(t *testing.T) {
 	r := require.New(t)
 	r.NoError(testhelpers.EnsureBuffaloCMD(t))


### PR DESCRIPTION
The current version of `buffalo` cli destroys the existing app directory (when the directory of the same name exists) even though `-d` option was given. This PR will fix the issue.