### PR TITLE
removed packr from mailer (fixes #177)

### DIFF
--- a/internal/genny/mail/init/templates/mailers/mailers.go.tmpl
+++ b/internal/genny/mail/init/templates/mailers/mailers.go.tmpl
@@ -3,10 +3,11 @@ package mailers
 import (
 	"log"
 
+	"{{ .opts.App.PackagePkg }}/templates"
+
 	"github.com/gobuffalo/buffalo/mail"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/envy"
-	"github.com/gobuffalo/packr/v2"
 )
 
 var (
@@ -29,8 +30,8 @@ func init() {
 	}
 
 	r = render.New(render.Options{
-		HTMLLayout:   "layout.html",
-		TemplatesBox: packr.New("app:mailers:templates", "../templates/mail"),
-		Helpers:      render.Helpers{},
+		HTMLLayout:  "mail/layout.plush.html",
+		TemplatesFS: templates.FS(),
+		Helpers:     render.Helpers{},
 	})
 }

--- a/internal/genny/mail/init/templates/templates/mail/layout.plush.html.tmpl
+++ b/internal/genny/mail/init/templates/templates/mail/layout.plush.html.tmpl
@@ -1,3 +1,3 @@
-<h1>templates/mailers/layout.plush.html</h1>
+<h1>templates/mail/layout.plush.html</h1>
 
 <%= yield %>

--- a/internal/genny/mail/mail.go
+++ b/internal/genny/mail/mail.go
@@ -72,8 +72,8 @@ func initGenerator(opts *Options) (*genny.Generator, error) {
 const mailerTmpl = `package mailers
 
 import (
-	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/mail"
+	"github.com/gobuffalo/buffalo/render"
 )
 
 func Send{{.opts.Name.Resource}}() error {
@@ -83,7 +83,7 @@ func Send{{.opts.Name.Resource}}() error {
 	m.Subject = "{{.opts.Name.Titleize}}"
 	m.From = ""
 	m.To = []string{}
-	err := m.AddBody(r.HTML("{{.opts.Name.File}}.html"), render.Data{})
+	err := m.AddBody(r.HTML("mail/{{.opts.Name.File}}.html"), render.Data{})
 	if err != nil {
 		return err
 	}
@@ -93,4 +93,4 @@ func Send{{.opts.Name.Resource}}() error {
 
 const mailTmpl = `<h2>{{.opts.Name.Titleize}}</h2>
 
-<h3>../templates/mail/{{.opts.Name.File}}.plush.html</h3>`
+<h3>templates/mail/{{.opts.Name.File}}.plush.html</h3>`

--- a/internal/genny/mail/mail_test.go
+++ b/internal/genny/mail/mail_test.go
@@ -25,7 +25,7 @@ func Test_New_NoMailers(t *testing.T) {
 	f := res.Files[0]
 	r.Equal("mailers/foo.go", f.Name())
 	body := f.String()
-	r.Contains(body, `err := m.AddBody(r.HTML("foo.html"), render.Data{})`)
+	r.Contains(body, `err := m.AddBody(r.HTML("mail/foo.html"), render.Data{})`)
 
 	f = res.Files[1]
 	r.Equal("mailers/mailers.go", f.Name())
@@ -33,7 +33,7 @@ func Test_New_NoMailers(t *testing.T) {
 	f = res.Files[2]
 	r.Equal("templates/mail/foo.plush.html", f.Name())
 	body = f.String()
-	r.Contains(body, `<h3>../templates/mail/foo.plush.html</h3>`)
+	r.Contains(body, `<h3>templates/mail/foo.plush.html</h3>`)
 
 	f = res.Files[3]
 	r.Equal("templates/mail/layout.plush.html", f.Name())
@@ -57,10 +57,10 @@ func Test_New_WithMailers(t *testing.T) {
 	f := res.Files[0]
 	r.Equal("mailers/foo.go", f.Name())
 	body := f.String()
-	r.Contains(body, `err := m.AddBody(r.HTML("foo.html"), render.Data{})`)
+	r.Contains(body, `err := m.AddBody(r.HTML("mail/foo.html"), render.Data{})`)
 
 	f = res.Files[2]
 	r.Equal("templates/mail/foo.plush.html", f.Name())
 	body = f.String()
-	r.Contains(body, `<h3>../templates/mail/foo.plush.html</h3>`)
+	r.Contains(body, `<h3>templates/mail/foo.plush.html</h3>`)
 }


### PR DESCRIPTION
* removed `packr` from the generated mailer and fixed related file paths
* updated modules (testify and x/sync)

fixes #177