### PR TITLE
replaced markbates/sigtx with standard signal

### DIFF
--- a/internal/cmd/build/build.go
+++ b/internal/cmd/build/build.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/gobuffalo/genny/v2"
 	"github.com/gobuffalo/logger"
 	"github.com/gobuffalo/meta"
-	"github.com/markbates/sigtx"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +34,7 @@ var buildOptions = struct {
 }
 
 func runE(cmd *cobra.Command, args []string) error {
-	ctx, cancel := sigtx.WithCancel(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
 	pwd, err := os.Getwd()

--- a/internal/cmd/fix/fix.go
+++ b/internal/cmd/fix/fix.go
@@ -3,16 +3,16 @@ package fix
 import (
 	"context"
 	"os"
+	"os/signal"
 
 	"github.com/gobuffalo/cli/internal/genny/fix"
 	"github.com/gobuffalo/genny/v2"
-	"github.com/markbates/sigtx"
 	"github.com/spf13/cobra"
 )
 
 // run all compatible checks
 func RunE(cmd *cobra.Command, args []string) error {
-	ctx, cancel := sigtx.WithCancel(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
 	opts := &fix.Options{


### PR DESCRIPTION
https://pkg.go.dev/os/signal#NotifyContext was added from go1.16 and the usage, API, and internal implementation are the same as `markbates/sigtx`. Just replaced them.

This is the only place using `sigtx` package within the buffalo family.