### PR TITLE
applied sync.Once to make 'app' to be the only root App

### DIFF
--- a/internal/genny/actions/_fixtures/inputs/clean/actions/app.go
+++ b/internal/genny/actions/_fixtures/inputs/clean/actions/app.go
@@ -1,18 +1,23 @@
 package actions
 
 import (
+	"sync"
+
 	"github.com/gobuffalo/buffalo"
 )
 
-var app *buffalo.App
+var (
+	app     *buffalo.App
+	appOnce sync.Once
+)
 
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{})
 		app.GET("/", HomeHandler)
 
 		app.ServeFiles("/", assetsBox) // serve files from the public directory
-	}
+	})
 
 	return app
 }

--- a/internal/genny/actions/_fixtures/outputs/clean/actions/app.go.tmpl
+++ b/internal/genny/actions/_fixtures/outputs/clean/actions/app.go.tmpl
@@ -1,19 +1,24 @@
 package actions
 
 import (
+	"sync"
+
 	"github.com/gobuffalo/buffalo"
 )
 
-var app *buffalo.App
+var (
+	app     *buffalo.App
+	appOnce sync.Once
+)
 
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{})
 		app.GET("/", HomeHandler)
 
 		app.GET("/user/index", UserIndex)
 		app.ServeFiles("/", assetsBox) // serve files from the public directory
-	}
+	})
 
 	return app
 }

--- a/internal/genny/actions/_fixtures/outputs/multi/actions/app.go.tmpl
+++ b/internal/genny/actions/_fixtures/outputs/multi/actions/app.go.tmpl
@@ -1,20 +1,25 @@
 package actions
 
 import (
+	"sync"
+
 	"github.com/gobuffalo/buffalo"
 )
 
-var app *buffalo.App
+var (
+	app     *buffalo.App
+	appOnce sync.Once
+)
 
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{})
 		app.GET("/", HomeHandler)
 
 		app.GET("/user/show", UserShow)
 		app.GET("/user/edit", UserEdit)
 		app.ServeFiles("/", assetsBox) // serve files from the public directory
-	}
+	})
 
 	return app
 }

--- a/internal/genny/actions/actions.go
+++ b/internal/genny/actions/actions.go
@@ -68,6 +68,7 @@ func updateApp(pres *presenter) genny.RunFn {
 		if err != nil {
 			return err
 		}
+
 		var lines []string
 		body := f.String()
 		for _, a := range pres.Actions {
@@ -76,9 +77,19 @@ func updateApp(pres *presenter) genny.RunFn {
 				lines = append(lines, e)
 			}
 		}
+
 		f, err = gogen.AddInsideBlock(f, "appOnce.Do(func() {", strings.Join(lines, "\n\t\t"))
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "could not find desired block") {
+				f, err = gogen.AddInsideBlock(f, "if app == nil {", strings.Join(lines, "\n\t\t"))
+				if err != nil {
+					return err
+				} else {
+					r.Logger.Warnf("This app was built with CLI v0.18.8 or older. See https://gobuffalo.io/documentation/known-issues/#cli-v0.18.8")
+				}
+			} else {
+				return err
+			}
 		}
 		return r.File(f)
 	}

--- a/internal/genny/actions/actions.go
+++ b/internal/genny/actions/actions.go
@@ -76,7 +76,7 @@ func updateApp(pres *presenter) genny.RunFn {
 				lines = append(lines, e)
 			}
 		}
-		f, err = gogen.AddInsideBlock(f, "app == nil", strings.Join(lines, "\n\t\t"))
+		f, err = gogen.AddInsideBlock(f, "appOnce.Do(func() {", strings.Join(lines, "\n\t\t"))
 		if err != nil {
 			return err
 		}

--- a/internal/genny/newapp/api/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/api/templates/actions/app.go.tmpl
@@ -1,6 +1,8 @@
 package actions
 
 import (
+	"sync"
+
 	{{ if .opts.App.WithPop -}}
 	"{{ .opts.App.ModelsPkg }}"
 	{{ end -}}
@@ -24,8 +26,9 @@ import (
 var ENV = envy.Get("GO_ENV", "development")
 
 var (
-	app *buffalo.App
-	T   *i18n.Translator
+	app     *buffalo.App
+	appOnce sync.Once
+	T       *i18n.Translator
 )
 
 // App is where all routes and middleware for buffalo
@@ -42,7 +45,7 @@ var (
 // placed last in the route declarations, as it will prevent routes
 // declared after it to never be called.
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{
 			Env:          ENV,
 			SessionStore: sessions.Null{},
@@ -69,7 +72,7 @@ func App() *buffalo.App {
 		{{ end -}}
 
 		app.GET("/", HomeHandler)
-	}
+	})
 
 	return app
 }

--- a/internal/genny/newapp/core/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/core/templates/actions/app.go.tmpl
@@ -1,6 +1,8 @@
 package actions
 
 import (
+	"sync"
+
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/envy"
 	forcessl "github.com/gobuffalo/mw-forcessl"
@@ -11,7 +13,11 @@ import (
 // ENV is used to help switch settings based on where the
 // application is being run. Default is "development".
 var ENV = envy.Get("GO_ENV", "development")
-var app *buffalo.App
+
+var (
+	app     *buffalo.App
+	appOnce sync.Once
+)
 
 // App is where all routes and middleware for buffalo
 // should be defined. This is the nerve center of your
@@ -27,7 +33,7 @@ var app *buffalo.App
 // placed last in the route declarations, as it will ensure routes
 // declared after it will never be called.
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{
 			Env:         ENV,
 			SessionName: "_{{.opts.App.Name.File}}_session",
@@ -40,7 +46,7 @@ func App() *buffalo.App {
 		app.Use(paramlogger.ParameterLogger)
 
 		app.GET("/", HomeHandler)
-	}
+	})
 
 	return app
 }

--- a/internal/genny/newapp/web/templates/actions/app.go.tmpl
+++ b/internal/genny/newapp/web/templates/actions/app.go.tmpl
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"net/http"
+	"sync"
 
 	"{{ .opts.App.PackagePkg }}/locales"
 	{{ if .opts.App.WithPop -}}
@@ -26,8 +27,9 @@ import (
 var ENV = envy.Get("GO_ENV", "development")
 
 var (
-	app *buffalo.App
-	T   *i18n.Translator
+	app     *buffalo.App
+	appOnce sync.Once
+	T       *i18n.Translator
 )
 
 // App is where all routes and middleware for buffalo
@@ -44,7 +46,7 @@ var (
 // placed last in the route declarations, as it will prevent routes
 // declared after it to never be called.
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{
 			Env:         ENV,
 			SessionName: "_{{.opts.App.Name.File}}_session",
@@ -73,7 +75,7 @@ func App() *buffalo.App {
 		app.GET("/", HomeHandler)
 
 		app.ServeFiles("/", http.FS(public.FS())) // serve files from the public directory
-	}
+	})
 
 	return app
 }

--- a/internal/genny/resource/_fixtures/default/actions/app.go.tmpl
+++ b/internal/genny/resource/_fixtures/default/actions/app.go.tmpl
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/markbates/coke/locales"
 	"github.com/markbates/coke/public"
@@ -20,8 +21,9 @@ import (
 var ENV = envy.Get("GO_ENV", "development")
 
 var (
-	app *buffalo.App
-	T   *i18n.Translator
+	app     *buffalo.App
+	appOnce sync.Once
+	T       *i18n.Translator
 )
 
 // App is where all routes and middleware for buffalo
@@ -38,7 +40,7 @@ var (
 // placed last in the route declarations, as it will prevent routes
 // declared after it to never be called.
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{
 			Env:         ENV,
 			SessionName: "_resource_session",
@@ -61,7 +63,7 @@ func App() *buffalo.App {
 
 		app.Resource("/widgets", WidgetsResource{})
 		app.ServeFiles("/", http.FS(public.FS())) // serve files from the public directory
-	}
+	})
 
 	return app
 }

--- a/internal/genny/resource/_fixtures/nested/actions/app.go.tmpl
+++ b/internal/genny/resource/_fixtures/nested/actions/app.go.tmpl
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/markbates/coke/locales"
 	"github.com/markbates/coke/public"
@@ -20,8 +21,9 @@ import (
 var ENV = envy.Get("GO_ENV", "development")
 
 var (
-	app *buffalo.App
-	T   *i18n.Translator
+	app     *buffalo.App
+	appOnce sync.Once
+	T       *i18n.Translator
 )
 
 // App is where all routes and middleware for buffalo
@@ -38,7 +40,7 @@ var (
 // placed last in the route declarations, as it will prevent routes
 // declared after it to never be called.
 func App() *buffalo.App {
-	if app == nil {
+	appOnce.Do(func() {
 		app = buffalo.New(buffalo.Options{
 			Env:         ENV,
 			SessionName: "_resource_session",
@@ -61,7 +63,7 @@ func App() *buffalo.App {
 
 		app.Resource("/admin/widgets", AdminWidgetsResource{})
 		app.ServeFiles("/", http.FS(public.FS())) // serve files from the public directory
-	}
+	})
 
 	return app
 }

--- a/internal/genny/resource/actions.go
+++ b/internal/genny/resource/actions.go
@@ -15,7 +15,7 @@ func addResource(pres presenter) genny.RunFn {
 			return err
 		}
 		stmt := fmt.Sprintf("app.Resource(\"/%s\", %sResource{})", pres.Name.URL(), pres.Name.Resource())
-		f, err = gogen.AddInsideBlock(f, "if app == nil {", stmt)
+		f, err = gogen.AddInsideBlock(f, "appOnce.Do(func() {", stmt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
(This is a fix for the v1)

Applied `sync.Once` for app initialization (template for scaffold) to fix #228 and gobuffalo/buffalo#1653. (actually the same issue, but keep them all in each project since this issue could be imaged as the core library's issue) It also related to the review discussion on https://github.com/gobuffalo/buffalo/pull/2239.

For the long term, this issue could be resolved by https://github.com/gobuffalo/buffalo/issues/2240

The first commit fixes the `App()` to use `sync.Once` for the initialization function. To make the CLI compatible with the old version of apps which was created with old versions, the second commit treats those errors and fallback to the old method.

It could be better to have a fixer for this, and I am considering that.

fixes #228
fixes https://github.com/gobuffalo/buffalo/issues/1653