### PR TITLE
improvement: using go built in build-info.

### DIFF
--- a/.github/workflows/standard-go-test.yml
+++ b/.github/workflows/standard-go-test.yml
@@ -8,5 +8,5 @@ on:
 jobs:
   call-standard-test:
     name: Test
-    uses: gobuffalo/.github/.github/workflows/go-test.yml@v1
+    uses: gobuffalo/.github/.github/workflows/go-test.yml@v1.6
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
This PR changes how we find the VCS part of the build info. It uses Go runtime/debug instead of shelling out to determine it.

### Which are the main considerations
One important consideration is the version of Go, Buffalo supports the last 2 versions, and Go latest version is 1.19 (1.20 coming soon). The library used is available since Go 1.18 so we should be good to go. 

### How did you test this?
I installed this new version of the CLI and make sure that after I compiled my binary it got the build info there by running:

```
$ mybinary version
```

### Did you discover anything while on this?
While on this one I discovered that the template workflows have versions. I had to tag a new version for the standard go tests (v1.6) on the .github repo and make this branch use it. That new version has the versions set to 1.18 and 1.19.