### PR TITLE
docker: adding `latest` and  `latest-slim` tags to our docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ dockers:
   - 
     image_templates:
       - gobuffalo/buffalo:{{ .Tag }}
+      - gobuffalo/buffalo:latest
     dockerfile: 'Dockerfile.build'
     goos: linux
     goarch: amd64
@@ -55,6 +56,7 @@ dockers:
   - 
     image_templates:
       - gobuffalo/buffalo:{{ .Tag }}-slim
+      - gobuffalo/buffalo:latest-slim
     dockerfile: 'Dockerfile.slim.build'
     goos: linux
     goarch: amd64


### PR DESCRIPTION
### What is being done in this PR?
> This PR adds `latest` and `latest-slim` to our GoReleaser file.

### What are the main choices made to get to this solution?
> Since the build was not working on Dockerhub we're updating `latest` and `latest-slim` with GoReleaser.

### What was discovered while working on it? (Optional)
> Discovered the many 

### List the manual test cases you've covered before sending this PR:
> - I did cut a pre-release from this branch and make sure it was pushed to Dockerhub by going to the site and checking it was there. Both, latest and latest-slim were there.
> - I also pulled the built image and make sure it had the correct tag when requested for the buffalo version. I correctly got: v0.18.12-beta.