### PR TITLE
build: Allow custom module import names

### DIFF
--- a/internal/cmd/build/build.go
+++ b/internal/cmd/build/build.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/cli/internal/genny/build"
@@ -25,6 +26,7 @@ var buildOptions = struct {
 	DryRun                 bool
 	Verbose                bool
 	bin                    string
+	WithCustomModule       bool
 }{
 	Options: &build.Options{
 		BuildTime: time.Now(),
@@ -43,6 +45,27 @@ func runE(cmd *cobra.Command, args []string) error {
 	buildOptions.App = meta.New(pwd)
 	if len(buildOptions.bin) > 0 {
 		buildOptions.App.Bin = buildOptions.bin
+	}
+	if buildOptions.WithCustomModule {
+		buildOptions.App.PackagePkg = buildOptions.App.Name.Original
+		actionsPkg := strings.Split(buildOptions.App.ActionsPkg, "/")
+		if len(actionsPkg) > 1 {
+			buildOptions.App.ActionsPkg = buildOptions.App.Name.Original + "/" + actionsPkg[1]
+		} else {
+			buildOptions.App.ActionsPkg = buildOptions.App.Name.Original + "/" + actionsPkg[0]
+		}
+		modelsPkg := strings.Split(buildOptions.App.ModelsPkg, "/")
+		if len(modelsPkg) > 1 {
+			buildOptions.App.ModelsPkg = buildOptions.App.Name.Original + "/" + modelsPkg[1]
+		} else {
+			buildOptions.App.ModelsPkg = buildOptions.App.Name.Original + "/" + modelsPkg[0]
+		}
+		griftsPkg := strings.Split(buildOptions.App.GriftsPkg, "/")
+		if len(griftsPkg) > 1 {
+			buildOptions.App.GriftsPkg = buildOptions.App.Name.Original + "/" + griftsPkg[1]
+		} else {
+			buildOptions.App.GriftsPkg = buildOptions.App.Name.Original + "/" + griftsPkg[0]
+		}
 	}
 
 	buildOptions.Options.WithAssets = !buildOptions.SkipAssets

--- a/internal/cmd/build/cmd.go
+++ b/internal/cmd/build/cmd.go
@@ -24,6 +24,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().StringVarP(&buildOptions.Environment, "environment", "", "development", "set the environment for the binary")
 	cmd.Flags().StringVar(&buildOptions.Mod, "mod", "", "-mod flag for go build")
 	cmd.Flags().StringSliceVar(&buildOptions.BuildFlags, "build-flags", nil, "Additional comma-separated build flags to feed to go build")
+	cmd.Flags().BoolVar(&buildOptions.WithCustomModule, "custom-mod", false, "Build using a custom module name configured in config.json's 'with_custom_module' field")
 
 	return cmd
 }


### PR DESCRIPTION
### What is being done in this PR
The existing code uses gobuffalo/meta to determine the module name, but strips the fully qualified name from it. This is fine when dealing with a buffalo project at the top level of a git repository/go module. However, if multiple projects share a single go.mod file higher up the directory tree this detection fails.

### What are the main choices made to get to this solution.
Using a build-time flag, restore the original fully qualified name of the module so the buffalo project can be built as a sub-package. Further ensure that actions/models/grifts are included in this.

An alternative solution would be to implement this as config option in gobuffalo/meta. I believe this is the cleaner solution, however, given https://github.com/gobuffalo/meta/issues/11 the current state of meta seems in question. I've implemented this directly in gobuffalo/cli instead.

### List the manual test cases you've covered before sending this PR:
Local builds of an existing buffalo project with and without a `go.mod` file at the root of the project and with/without the new build flag. At least on my repository this works as expected.